### PR TITLE
fix: uninstall test scenario should install Postfix first

### DIFF
--- a/molecule/uninstall/converge.yml
+++ b/molecule/uninstall/converge.yml
@@ -1,9 +1,16 @@
 ---
-- name: Converge to state where postfix is removed
+- name: Converge to state where a previously installed Postfix is removed
   hosts: all
 
   tasks:
-    - name: "Remove Postfix from the system"
+    - name: "Install Postfix with defaults on the system"
+      ansible.builtin.include_role:
+        name: "unibe_idsys.postfix"
+
+    - name: "Flush handlers"
+      ansible.builtin.meta: flush_handlers
+
+    - name: "Remove Postfix from the system again"
       ansible.builtin.include_role:
         name: "unibe_idsys.postfix"
       vars:


### PR DESCRIPTION
To be able to remove Postfix, the converge script should first install
Postfix. This is now added. The meta module that flushes the handlers is
needed as the handlers would flush at the very end of the playbook, when
Postfix was removed again.

# Closes issue(s)

Fixes #4

# Changes include
- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [X] I have tested this code
- [X] I have updated the README.md (if available and necessary)
