### PR TITLE
Fix sender_canonical_maps param in templates

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -90,6 +90,15 @@
       register: sender_canonical
       failed_when: sender_canonical is changed
 
+    - name: Parameter sender_canonical_maps is not set
+      ansible.builtin.lineinfile:
+        path: /etc/postfix/main.cf
+        regexp: "^sender_canonical_maps"
+        state: absent
+      check_mode: true
+      register: sender_canonical_maps
+      failed_when: sender_canonical_maps.found
+
     - name: Postfix service is running
       ansible.builtin.wait_for:
         port: 25

--- a/molecule/lookup-tables/verify.yml
+++ b/molecule/lookup-tables/verify.yml
@@ -44,12 +44,12 @@
       changed_when: false
       failed_when: not ldap_option.found
 
-    - name: Check if both tables are in the sender_canonical_map
+    - name: Check if both tables are set in the sender_canonical_map
       ansible.builtin.lineinfile:
         path: /etc/postfix/main.cf
-        regexp: "^sender_canonical_map = hash:/etc/postfix/sender_canonical, ldap:/etc/postfix/ldap-sender_canonical.cf$"
+        regexp: "^sender_canonical_maps = hash:/etc/postfix/sender_canonical, ldap:/etc/postfix/ldap-sender_canonical.cf"
         state: absent
       check_mode: true
-      register: ldap_option
+      register: sender_canonical_maps
       changed_when: false
-      failed_when: not ldap_option.found
+      failed_when: not sender_canonical_maps.found

--- a/templates/main.cf-debian.j2
+++ b/templates/main.cf-debian.j2
@@ -56,5 +56,5 @@ inet_interfaces = {{ postfix_inet_interfaces }}
 inet_protocols = {{ postfix_inet_protocols }}
 
 {% if __postfix_sender_canonical_maps | length > 0 %}
-sender_canonical_map = {{ __postfix_sender_canonical_maps | join(", ") }}
+sender_canonical_maps = {{ __postfix_sender_canonical_maps | join(", ") }}
 {% endif %}

--- a/templates/main.cf-redhat.j2
+++ b/templates/main.cf-redhat.j2
@@ -751,5 +751,5 @@ meta_directory = /etc/postfix
 shlib_directory = /usr/lib64/postfix
 
 {% if __postfix_sender_canonical_maps | length > 0 %}
-sender_canonical_map = {{ __postfix_sender_canonical_maps | join(", ") }}
+sender_canonical_maps = {{ __postfix_sender_canonical_maps | join(", ") }}
 {% endif %}


### PR DESCRIPTION
- fix: correct parameter name for sender_canonicals

# Closes issue(s)

Fixes #8

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [x] I have updated the README.md (if available and necessary)
