### PR TITLE
Support multiline ansible_managed strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,18 @@ on:
       - main
 
 jobs:
-
   lint:
     name: Lint
     runs-on: ubuntu-latest
 
     steps:
-
       - name: Checkout the codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install test dependencies.
         run: pip3 install yamllint ansible-lint
@@ -37,19 +35,19 @@ jobs:
     # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy
     strategy:
       matrix:
-        distro: [rockylinux8, rockylinux9, ubuntu2004, ubuntu2204]
+        distro: [rockylinux9, ubuntu2004, ubuntu2204]
         scenario: [default, local, remove-alias, uninstall]
         include:
           - playbook: converge.yml
 
     steps:
       - name: Checkout the codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install test dependencies.
         run: pip3 install ansible molecule 'molecule-plugins[podman]' podman
@@ -57,7 +55,7 @@ jobs:
       - name: Run Molecule tests.
         run: molecule test -s ${{ matrix.scenario }}
         env:
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"
           MOLECULE_DISTRO: ${{ matrix.distro }}
           MOLECULE_PLAYBOOK: ${{ matrix.playbook }}

--- a/templates/configfile.j2
+++ b/templates/configfile.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {% for param, value in __postfix_config_params.items() %}
 {{ param }} = {{ value }}

--- a/templates/main.cf-debian.j2
+++ b/templates/main.cf-debian.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 #
 # See /usr/share/postfix/main.cf.dist for a commented, more complete version
 

--- a/templates/main.cf-redhat.j2
+++ b/templates/main.cf-redhat.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 #
 # Global Postfix configuration file. This file lists only a subset
 # of all parameters. For the syntax, and for a complete parameter

--- a/templates/mapfile.j2
+++ b/templates/mapfile.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {% for mapping in __postfix_mappings %}
 {% for key, value in mapping.items() %}


### PR DESCRIPTION
This changes makes sure that multiline ansible_managed string get
rendered correctly. This is the method advertised in the [official Ansible
documentation](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_filters.html#adding-comments-to-files).

Fixes #19
