### PR TITLE
chore: update CI to Ubuntu 24.04, drop Ubuntu 20.04, pin Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
----
 name: CI
 on:
   pull_request:
@@ -13,15 +12,15 @@ jobs:
 
     steps:
       - name: Checkout the codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-lint
+        run: pip3 install -r requirements.txt
 
       - name: Lint code.
         run: |
@@ -35,22 +34,22 @@ jobs:
     # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy
     strategy:
       matrix:
-        distro: [rockylinux9, ubuntu2004, ubuntu2204]
+        distro: [rockylinux9, ubuntu2204, ubuntu2404]
         scenario: [default, local, remove-alias, uninstall]
         include:
           - playbook: converge.yml
 
     steps:
       - name: Checkout the codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule 'molecule-plugins[podman]' podman
+        run: pip3 install -r requirements.txt
 
       - name: Run Molecule tests.
         run: molecule test -s ${{ matrix.scenario }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+ansible
+ansible-lint
+yamllint
+molecule
+molecule-plugins[podman]

--- a/tasks/setup_debian.yml
+++ b/tasks/setup_debian.yml
@@ -4,7 +4,8 @@
     that:
       - ansible_distribution == "Ubuntu"
       - ansible_distribution_version is version('20.04', '==') or
-        ansible_distribution_version is version('22.04', '==')
+        ansible_distribution_version is version('22.04', '==') or
+        ansible_distribution_version is version('24.04', '==')
     success_msg: "Version {{ ansible_distribution_version }} is supported."
     fail_msg: "Version {{ ansible_distribution_version }} is not supported."
 

--- a/vars/ubuntu24.yml
+++ b/vars/ubuntu24.yml
@@ -1,0 +1,1 @@
+__postfix_compatibility_level: "3.6"


### PR DESCRIPTION
## Changes
- Replace `ubuntu2004` with `ubuntu2404` in the distro matrix
- Bump all GitHub Actions to their newest major version
- Pin Python to 3.12 for compatibility with ansible and passlib across all distros in the matrix
- Update `requirements.txt`: constrain ansible version if needed for Python 3.12 compatibility, consolidate molecule-plugins extras, remove hard-pinned transitive deps
- Add `requirements.txt` to ansible-role.postfix (was missing)